### PR TITLE
Replace the unnecessary `replaceAll` calls with `replace`

### DIFF
--- a/Common/source/customskinloader/loader/LegacyLoader.java
+++ b/Common/source/customskinloader/loader/LegacyLoader.java
@@ -17,14 +17,14 @@ import customskinloader.utils.HttpTextureUtil;
 import customskinloader.utils.HttpUtil0;
 
 public class LegacyLoader implements ProfileLoader.IProfileLoader {
-    public static final String USERNAME_REGEX="\\{USERNAME\\}";
+    public static final String USERNAME_PLACEHOLDER="{USERNAME}";
     
     @Override
     public UserProfile loadProfile(SkinSiteProfile ssp, GameProfile gameProfile) throws Exception {
         String username=gameProfile.getName();
         UserProfile profile=new UserProfile();
         if(StringUtils.isNoneEmpty(ssp.skin)){
-            String skin=ssp.skin.replaceAll(USERNAME_REGEX, username);
+            String skin=ssp.skin.replace(USERNAME_PLACEHOLDER, username);
             if(HttpUtil0.isLocal(ssp.skin)){
                 File skinFile=new File(CustomSkinLoader.DATA_DIR,skin);
                 if(skinFile.exists()&&skinFile.isFile())
@@ -37,7 +37,7 @@ public class LegacyLoader implements ProfileLoader.IProfileLoader {
             profile.model=profile.hasSkinUrl()?ssp.model:null;
         }
         if(StringUtils.isNoneEmpty(ssp.cape)){
-            String cape=ssp.cape.replaceAll(USERNAME_REGEX, username);
+            String cape=ssp.cape.replace(USERNAME_PLACEHOLDER, username);
             if(HttpUtil0.isLocal(ssp.cape)){
                 File capeFile=new File(CustomSkinLoader.DATA_DIR,cape);
                 if(capeFile.exists()&&capeFile.isFile())
@@ -49,7 +49,7 @@ public class LegacyLoader implements ProfileLoader.IProfileLoader {
             }
         }
         if(ModelManager0.isElytraSupported()&&StringUtils.isNoneEmpty(ssp.elytra)){
-            String elytra=ssp.elytra.replaceAll(USERNAME_REGEX, username);
+            String elytra=ssp.elytra.replace(USERNAME_PLACEHOLDER, username);
             if(HttpUtil0.isLocal(ssp.elytra)){
                 File elytraFile=new File(CustomSkinLoader.DATA_DIR,elytra);
                 if(elytraFile.exists()&&elytraFile.isFile())
@@ -87,7 +87,7 @@ public class LegacyLoader implements ProfileLoader.IProfileLoader {
     }
     @SuppressWarnings("ResultOfMethodCallIgnored")
     private void initFolder(String target){
-        String file=target.replaceAll(USERNAME_REGEX, "init");
+        String file=target.replace(USERNAME_PLACEHOLDER, "init");
         File folder=new File(CustomSkinLoader.DATA_DIR,file).getParentFile();
         if(folder!=null&&!folder.exists())
             folder.mkdirs();

--- a/Vanilla/customskinloader/tweaker/ClassTransformer.java
+++ b/Vanilla/customskinloader/tweaker/ClassTransformer.java
@@ -89,11 +89,11 @@ public class ClassTransformer implements IClassTransformer {
         if (zipFile == null)
             return bytes;
         
-        String fullName = (name.startsWith("net") ? name.replaceAll("\\.", "\\/") : name) + ".class";//Notch(Run)/MCP(Dev) Class Name
+        String fullName = (name.startsWith("net") ? name.replace('.', '/') : name) + ".class";//Notch(Run)/MCP(Dev) Class Name
         if(!classes.contains(fullName)){//Check Name
             if(name.equals(transformedName))
                 return bytes;
-            fullName = transformedName.replaceAll("\\.", "\\/") + ".class";//MCP Class Name
+            fullName = transformedName.replace('.', '/') + ".class";//MCP Class Name
             if(!classes.contains(fullName))//check Again
                 return bytes;
         }


### PR DESCRIPTION
`String.replaceAll` 只在需要正则表达式匹配的情况下才有用，如果没有用正则表达式的需求， `String.replace` 会快得多。毕竟正则表达式引擎是个很重型的东西。