### PR TITLE
Fix for usernames containing characters not supported in URLs

### DIFF
--- a/Common/source/customskinloader/utils/HttpRequestUtil.java
+++ b/Common/source/customskinloader/utils/HttpRequestUtil.java
@@ -115,7 +115,17 @@ public class HttpRequestUtil {
             }
 
             //Init Connection
-            String url = new URI(request.url).toASCIIString();
+            URL rawUrl = new URL(request.url);
+            URI uri = new URI(
+                rawUrl.getProtocol(),
+                rawUrl.getUserInfo(),
+                rawUrl.getHost(),
+                rawUrl.getPort(),
+                rawUrl.getPath(),
+                rawUrl.getQuery(),
+                rawUrl.getRef()
+            );
+            String url = uri.toASCIIString();
             if (!url.equalsIgnoreCase(request.url))
                 CustomSkinLoader.logger.debug("Encoded URL: " + url);
             HttpURLConnection c = (HttpURLConnection) (new URL(url)).openConnection();


### PR DESCRIPTION
Noticed CSL wasn't working for usernames with spaces, here's an easy fix to escape illegal characters in the URL.

I know it's a bit ugly, see https://stackoverflow.com/questions/10786042/java-url-encoding-of-query-string-parameters for some alternative methods at the cost of more dependencies.