### PR TITLE
Improve downloading http textures.

### DIFF
--- a/Common/source/customskinloader/config/Config.java
+++ b/Common/source/customskinloader/config/Config.java
@@ -28,6 +28,7 @@ public class Config {
     public boolean forceLoadAllTextures=false;
     public boolean enableCape = true;
     public int threadPoolSize = 1;
+    public int retryTime = 3;
 
     //Cache
     public int cacheExpiry=30;
@@ -58,6 +59,7 @@ public class Config {
         config.loadExtraList();
         config.initLocalFolder();
         config.threadPoolSize = Math.max(config.threadPoolSize, 1);
+        config.retryTime = Math.max(config.retryTime, 0);
         if(config.ignoreHttpsCertificate)
             HttpUtil0.ignoreHttpsCertificate();
         if(config.enableCacheAutoClean && !config.enableLocalProfileCache){

--- a/Common/source/customskinloader/fake/FakeThreadDownloadImageData.java
+++ b/Common/source/customskinloader/fake/FakeThreadDownloadImageData.java
@@ -1,0 +1,101 @@
+package customskinloader.fake;
+
+import java.io.File;
+import java.util.EnumMap;
+import java.util.function.Supplier;
+
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
+import customskinloader.CustomSkinLoader;
+import customskinloader.utils.HttpRequestUtil;
+import net.minecraft.client.renderer.IImageBuffer;
+import net.minecraft.client.renderer.ThreadDownloadImageData;
+import net.minecraft.client.renderer.texture.DownloadingTexture;
+import net.minecraft.client.renderer.texture.SimpleTexture;
+import net.minecraft.util.ResourceLocation;
+
+public class FakeThreadDownloadImageData {
+    private static IThreadDownloadImageDataBuilder builder;
+
+    public static SimpleTexture createThreadDownloadImageData(File cacheFileIn, String imageUrlIn, ResourceLocation textureResourceLocationIn, IImageBuffer imageBufferIn, MinecraftProfileTexture.Type textureTypeIn) {
+        SimpleTexture texture = null;
+        if (FakeThreadDownloadImageData.builder == null) {
+            EnumMap<ThreadDownloadImageDataBuilder, Throwable> throwables = new EnumMap<>(ThreadDownloadImageDataBuilder.class);
+            for (ThreadDownloadImageDataBuilder builder : ThreadDownloadImageDataBuilder.values()) {
+                try {
+                    FakeThreadDownloadImageData.builder = builder.get().get();
+                    texture = FakeThreadDownloadImageData.builder.build(cacheFileIn, imageUrlIn, textureResourceLocationIn, imageBufferIn, textureTypeIn);
+                    CustomSkinLoader.logger.info("ThreadDownloadImageData Class: %s", texture.getClass().getName());
+                    break;
+                } catch (Throwable t) {
+                    throwables.put(builder, t);
+                }
+            }
+
+            if (texture == null) {
+                CustomSkinLoader.logger.warning("Unable to get ThreadDownloadImageData Class: ");
+                throwables.forEach((k, v) -> {
+                    CustomSkinLoader.logger.warning("Caused by: (%s)", k.name());
+                    CustomSkinLoader.logger.warning(v);
+                });
+                throw new RuntimeException("Unable to get ThreadDownloadImageData Class!");
+            }
+        } else {
+            texture = builder.build(cacheFileIn, imageUrlIn, textureResourceLocationIn, imageBufferIn, textureTypeIn);
+        }
+        return texture;
+    }
+
+    public static void downloadTexture(File cacheFile, String imageUrl) {
+        HttpRequestUtil.HttpRequest request = new HttpRequestUtil.HttpRequest(imageUrl).setLoadContent(false).setCacheTime(0).setCacheFile(cacheFile);
+        for (int i = 0; i <= CustomSkinLoader.config.retryTime; i++) {
+            if (i != 0) {
+                CustomSkinLoader.logger.debug("Retry to download texture %s (%s)", imageUrl, i);
+            }
+            if (HttpRequestUtil.makeHttpRequest(request).success) {
+                break;
+            }
+        }
+    }
+
+    private interface IThreadDownloadImageDataBuilder {
+        SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType);
+    }
+
+    private enum ThreadDownloadImageDataBuilder {
+        // DO NOT replace new IThreadDownloadImageDataBuilder() with lambda.
+        V1(() -> new IThreadDownloadImageDataBuilder() { // Forge 1.8.x~1.12.x
+            @Override
+            public SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType) {
+                return new ThreadDownloadImageData(cacheFile, imageUrl, textureResourceLocation, imageBuffer);
+            }
+        }),
+        V2(() -> new IThreadDownloadImageDataBuilder() { // Forge 1.13.x
+            @Override
+            public SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType) {
+                return new net.minecraft.client.renderer.texture.ThreadDownloadImageData(cacheFile, imageUrl, textureResourceLocation, imageBuffer);
+            }
+        }),
+        V3(() -> new IThreadDownloadImageDataBuilder() { // Forge 1.14.x
+            @Override
+            public SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType) {
+                return new DownloadingTexture(cacheFile, imageUrl, textureResourceLocation, imageBuffer);
+            }
+        }),
+        V4(() -> new IThreadDownloadImageDataBuilder() { // Forge 1.15.x~1.16.x
+            @Override
+            public SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType) {
+                return new DownloadingTexture(cacheFile, imageUrl, textureResourceLocation, textureType == MinecraftProfileTexture.Type.SKIN, imageBuffer);
+            }
+        });
+
+        private final Supplier<IThreadDownloadImageDataBuilder> builder;
+
+        ThreadDownloadImageDataBuilder(Supplier<IThreadDownloadImageDataBuilder> builder) {
+            this.builder = builder;
+        }
+
+        public Supplier<IThreadDownloadImageDataBuilder> get() {
+            return this.builder;
+        }
+    }
+}

--- a/Common/source/customskinloader/utils/HttpRequestUtil.java
+++ b/Common/source/customskinloader/utils/HttpRequestUtil.java
@@ -208,7 +208,7 @@ public class HttpRequestUtil {
             return responce;
 
         } catch (Exception e) {
-            CustomSkinLoader.logger.debug("Failed to request (Exception: " + e.toString() + ")");
+            CustomSkinLoader.logger.debug("Failed to request " + request.url + " (Exception: " + e.toString() + ")");
             return loadFromCache(request, new HttpResponce());
         }
     }
@@ -224,7 +224,7 @@ public class HttpRequestUtil {
     private static HttpResponce loadFromCache(HttpRequest request, HttpResponce responce, long expireTime) {
         if (request.cacheFile == null || !request.cacheFile.isFile())
             return responce;
-        CustomSkinLoader.logger.debug("Cache file found (Length: " + request.cacheFile.length() + " , Path: '" + request.cacheFile.getAbsolutePath() + "' , Expire: " + expireTime + "')");
+        CustomSkinLoader.logger.debug("Cache file found (Length: " + request.cacheFile.length() + " , Path: '" + request.cacheFile.getAbsolutePath() + "' , Expire: " + expireTime + ")");
         responce.fromCache = true;
         responce.success = true;
         if (!request.loadContent)

--- a/Common/source/customskinloader/utils/MinecraftUtil.java
+++ b/Common/source/customskinloader/utils/MinecraftUtil.java
@@ -1,7 +1,6 @@
 package customskinloader.utils;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -9,14 +8,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.minecraft.MinecraftProfileTexture;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.IImageBuffer;
-import net.minecraft.client.renderer.ThreadDownloadImageData;
-import net.minecraft.client.renderer.texture.SimpleTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.resources.SkinManager;
-import net.minecraft.util.ResourceLocation;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -34,42 +28,6 @@ public class MinecraftUtil {
 
     public static SkinManager getSkinManager() {
         return Minecraft.getMinecraft().getSkinManager();
-    }
-
-    private static boolean is_1_15_plus = false;
-    private static Constructor<?> constructor = null;
-    public static SimpleTexture createThreadDownloadImageData(File cacheFileIn, String imageUrlIn, ResourceLocation textureResourceLocation, IImageBuffer imageBufferIn, MinecraftProfileTexture.Type textureType) {
-        if (constructor == null) {
-            Class<?> c;
-            try {
-                c = Class.forName("net.minecraft.client.renderer.texture.ThreadDownloadImageData", false, MinecraftUtil.class.getClassLoader()); // Forge 1.13
-            } catch (ClassNotFoundException e1) {
-                try {
-                    c = Class.forName("net.minecraft.client.renderer.texture.DownloadingTexture", false, MinecraftUtil.class.getClassLoader()); // Forge 1.14+
-                } catch (ClassNotFoundException e2) {
-                    c = ThreadDownloadImageData.class; // Forge 1.12- or Fabric or Vanilla
-                }
-            }
-            try {
-                constructor = c.getConstructor(File.class, String.class, ResourceLocation.class, boolean.class, Runnable.class); // For 1.15+
-                is_1_15_plus = true;
-            } catch (NoSuchMethodException e1) {
-                try {
-                    constructor = c.getConstructor(File.class, String.class, ResourceLocation.class, IImageBuffer.class); // For 1.15-
-                } catch (NoSuchMethodException e2) {
-                    throw new RuntimeException(e2);
-                }
-            }
-        }
-        try {
-            if (is_1_15_plus) {
-                return (SimpleTexture) constructor.newInstance(cacheFileIn, imageUrlIn, textureResourceLocation, textureType == MinecraftProfileTexture.Type.SKIN, imageBufferIn);
-            } else {
-                return (SimpleTexture) constructor.newInstance(cacheFileIn, imageUrlIn, textureResourceLocation, imageBufferIn);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
 


### PR DESCRIPTION
1. 部分启动器会不正确地添加代理参数，导致皮肤和披风下载失败（参见 https://github.com/huanghongxun/HMCL/issues/774 以及 2020 年 7 月 27 日 CSL 交流群内聊天记录），所以取消了使用 Minecraft 内自己的代理的设定
1. 目前玩家皮肤和披风下载失败的日志是写在 `.minecraft/logs/latest.log` 内，而不是 `.minecraft/CustomSkinLoader/CustomSkinLoader.log` 内，导致排查问题会出现一定困难，所以重新实现了下载皮肤和披风图片的逻辑
1. 有部分玩家会设置高清皮肤和披风，图片体积比较大，导致下载失败几率较高，所以添加了重试次数