### PR TITLE
Make sure the mod being absent on the other network side does not cause the client to display the server as incompatible after forge-1.13.2-25.0.107.

### DIFF
--- a/Forge/resource/transformers.js
+++ b/Forge/resource/transformers.js
@@ -1,5 +1,4 @@
 var FieldInsnNode = Java.type('org.objectweb.asm.tree.FieldInsnNode');
-var InsnList = Java.type('org.objectweb.asm.tree.InsnList');
 var InsnNode = Java.type('org.objectweb.asm.tree.InsnNode');
 var MethodInsnNode = Java.type('org.objectweb.asm.tree.MethodInsnNode');
 var VarInsnNode = Java.type('org.objectweb.asm.tree.VarInsnNode');
@@ -40,10 +39,8 @@ function initializeCoreMod() {
             'transformer': function (cn) {
                 cn.methods.forEach(function (mn) {
                     if (mn.name === 'func_174884_b') {
-                        var il = new InsnList();
-                        il.add(new VarInsnNode(Opcodes.ALOAD, 0));
-                        il.add(new InsnNode(Opcodes.ARETURN));
-                        mn.instructions.insert(il);
+                        mn.instructions.insert(new InsnNode(Opcodes.ARETURN));
+                        mn.instructions.insert(new VarInsnNode(Opcodes.ALOAD, 0));
                     }
                 });
                 return cn;

--- a/Forge/source/customskinloader/forge/ForgeMod.java
+++ b/Forge/source/customskinloader/forge/ForgeMod.java
@@ -1,10 +1,12 @@
 package customskinloader.forge;
 
 import customskinloader.CustomSkinLoader;
-
+import net.minecraftforge.fml.ExtensionPoint;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLFingerprintViolationEvent;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Forge Mod Container
@@ -20,8 +22,15 @@ import net.minecraftforge.fml.common.event.FMLFingerprintViolationEvent;
         certificateFingerprint = "52885f395e68f42e9b3b629ba56ecf606f7d4269"
 )//1.13-
 public class ForgeMod {
+    public ForgeMod() {
+        try {
+            this.setExtensionPoint();
+        } catch (Throwable ignored) {
+            // before forge-1.13.2-25.0.103
+        }
+    }
 
-    @EventHandler
+    @Mod.EventHandler
     public void fingerprintError(FMLFingerprintViolationEvent event) {
         if (event.isDirectory()) return;//Development Environment
 
@@ -37,5 +46,10 @@ public class ForgeMod {
         }
 
         throw new RuntimeException("Fingerprint ERROR, please **DO NOT MODIFY** any mod.");
+    }
+
+    // Make sure the mod being absent on the other network side does not cause the client to display the server as incompatible after forge-1.13.2-25.0.107.
+    private void setExtensionPoint() {
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (remote, isServer) -> true));
     }
 }

--- a/Forge/source/net/minecraftforge/fml/ExtensionPoint.java
+++ b/Forge/source/net/minecraftforge/fml/ExtensionPoint.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.fml;
+
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+public class ExtensionPoint<T> {
+    public static ExtensionPoint<Pair<Supplier<String>, BiPredicate<String, Boolean>>> DISPLAYTEST;
+}

--- a/Forge/source/net/minecraftforge/fml/ModLoadingContext.java
+++ b/Forge/source/net/minecraftforge/fml/ModLoadingContext.java
@@ -1,0 +1,13 @@
+package net.minecraftforge.fml;
+
+import java.util.function.Supplier;
+
+public class ModLoadingContext {
+    public static ModLoadingContext get() {
+        return null;
+    }
+
+    public <T> void registerExtensionPoint(ExtensionPoint<T> point, Supplier<T> extension) {
+
+    }
+}

--- a/Forge/source/net/minecraftforge/fml/network/FMLNetworkConstants.java
+++ b/Forge/source/net/minecraftforge/fml/network/FMLNetworkConstants.java
@@ -1,0 +1,5 @@
+package net.minecraftforge.fml.network;
+
+public class FMLNetworkConstants {
+    public static String IGNORESERVERONLY;
+}


### PR DESCRIPTION
have test in below versions:
- forge-1.8-11.14.0.1237
- forge-1.12.2-14.23.5.2854
- forge-1.13.2-25.0.103
- forge-1.13.2-25.0.107
- forge-1.16.3-34.1.35

*See:*
> But apart from that these mods should be aware of the fact that they're supposed to be client side only. However they're naughty and do not override the DISPLAYTEST extensionpoint, where they would have the option of not interfering with the client compatibility checking. So if you want this fixed and the mods can't simply be put onto the server, go yell at their authors.

[MinecraftForge/MinecraftForge#6329 (comment)](https://github.com/MinecraftForge/MinecraftForge/issues/6329#issuecomment-558387949)

[FORGE Docs - Writing One-Sided Mods](https://mcforge.readthedocs.io/en/1.16.x/concepts/sides/#writing-one-sided-mods)

### Before PR
![image](https://user-images.githubusercontent.com/41327811/97775653-73b52980-1b9d-11eb-97b7-9287c495af4c.png)

### After PR
![image](https://user-images.githubusercontent.com/41327811/97775690-bd9e0f80-1b9d-11eb-9464-5b27a0744e46.png)
