### PR TITLE
Remove updateGameProfile transformer.

### DIFF
--- a/Common/source/customskinloader/config/Config.java
+++ b/Common/source/customskinloader/config/Config.java
@@ -27,6 +27,7 @@ public class Config {
     public boolean forceIgnoreHttpsCertificate = false;
     public boolean forceLoadAllTextures=false;
     public boolean enableCape = true;
+    public boolean forceFillSkullNBT = false;
     public int threadPoolSize = 3;
     public int retryTime = 1;
 

--- a/Forge/resource/transformers.js
+++ b/Forge/resource/transformers.js
@@ -2,6 +2,8 @@ var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI');
 var Opcodes = Java.type('org.objectweb.asm.Opcodes');
 var FieldInsnNode = Java.type('org.objectweb.asm.tree.FieldInsnNode');
 var InsnNode = Java.type('org.objectweb.asm.tree.InsnNode');
+var JumpInsnNode = Java.type('org.objectweb.asm.tree.JumpInsnNode');
+var LabelNode = Java.type('org.objectweb.asm.tree.LabelNode');
 var MethodInsnNode = Java.type('org.objectweb.asm.tree.MethodInsnNode');
 var VarInsnNode = Java.type('org.objectweb.asm.tree.VarInsnNode');
 
@@ -55,8 +57,14 @@ function initializeCoreMod() {
             'transformer': function (cn) {
                 cn.methods.forEach(function (mn) {
                     if (checkName(mn.name, "func_174884_b", "updateGameProfile")) {
-                        mn.instructions.insert(new InsnNode(Opcodes.ARETURN));
-                        mn.instructions.insert(new VarInsnNode(Opcodes.ALOAD, 0));
+                        var first = mn.instructions.getFirst();
+                        var label = new LabelNode();
+                        mn.instructions.insertBefore(first, new FieldInsnNode(Opcodes.GETSTATIC, "customskinloader/CustomSkinLoader", "config", "Lcustomskinloader/config/Config;"));
+                        mn.instructions.insertBefore(first, new FieldInsnNode(Opcodes.GETFIELD, "customskinloader/config/Config", "forceFillSkullNBT", "Z"));
+                        mn.instructions.insertBefore(first, new JumpInsnNode(Opcodes.IFNE, label));
+                        mn.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 0));
+                        mn.instructions.insertBefore(first, new InsnNode(Opcodes.ARETURN));
+                        mn.instructions.insertBefore(first, label);
                     }
                 });
                 return cn;

--- a/Forge/source/customskinloader/forge/transformer/TileEntitySkullTransformer.java
+++ b/Forge/source/customskinloader/forge/transformer/TileEntitySkullTransformer.java
@@ -3,9 +3,12 @@ package customskinloader.forge.transformer;
 import customskinloader.forge.TransformerManager;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.FrameNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.VarInsnNode;
 
@@ -19,8 +22,14 @@ public class TileEntitySkullTransformer {
         @Override
         public MethodNode transform(ClassNode cn, MethodNode mn) {
             InsnList il = new InsnList();
+            LabelNode ln = new LabelNode();
+            il.add(new FieldInsnNode(Opcodes.GETSTATIC, "customskinloader/CustomSkinLoader", "config", "Lcustomskinloader/config/Config;"));
+            il.add(new FieldInsnNode(Opcodes.GETFIELD, "customskinloader/config/Config", "forceFillSkullNBT", "Z"));
+            il.add(new JumpInsnNode(Opcodes.IFNE, ln));
             il.add(new VarInsnNode(Opcodes.ALOAD, 0));
             il.add(new InsnNode(Opcodes.ARETURN));
+            il.add(new FrameNode(Opcodes.F_SAME, 0, null, 0, null));
+            il.add(ln);
             il.add(new FrameNode(Opcodes.F_SAME, 0, null, 0, null));
             mn.instructions.insert(il);
             return mn;

--- a/Forge/source/customskinloader/forge/transformer/TileEntitySkullTransformer.java
+++ b/Forge/source/customskinloader/forge/transformer/TileEntitySkullTransformer.java
@@ -28,7 +28,6 @@ public class TileEntitySkullTransformer {
             il.add(new JumpInsnNode(Opcodes.IFNE, ln));
             il.add(new VarInsnNode(Opcodes.ALOAD, 0));
             il.add(new InsnNode(Opcodes.ARETURN));
-            il.add(new FrameNode(Opcodes.F_SAME, 0, null, 0, null));
             il.add(ln);
             il.add(new FrameNode(Opcodes.F_SAME, 0, null, 0, null));
             mn.instructions.insert(il);

--- a/Vanilla/source/customskinloader/mixin/MixinTileEntitySkull.java
+++ b/Vanilla/source/customskinloader/mixin/MixinTileEntitySkull.java
@@ -1,6 +1,7 @@
 package customskinloader.mixin;
 
 import com.mojang.authlib.GameProfile;
+import customskinloader.CustomSkinLoader;
 import net.minecraft.tileentity.TileEntitySkull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,6 +16,8 @@ public abstract class MixinTileEntitySkull {
         cancellable = true
     )
     private static void inject_updateGameProfile(GameProfile input, CallbackInfoReturnable<GameProfile> callbackInfoReturnable) {
-        callbackInfoReturnable.setReturnValue(input);
+        if (!CustomSkinLoader.config.forceFillSkullNBT) {
+            callbackInfoReturnable.setReturnValue(input);
+        }
     }
 }


### PR DESCRIPTION
Reopen https://github.com/xfl03/MCCustomSkinLoader/issues/79

个人觉得一方面让一个纯客户端 Mod 来修改与服务端有关联的内容是不合适的，另一方面直接移除整个方法体可能会引发新的问题，因为有其他 Mod 会调用它（例如 JourneyMap 在 `journeymap.client.render.texture.IgnSkin#getFaceImage(java.util.UUID, java.lang.String)` 中也调用了这个方法，导致 CSL 和 JourneyMap 一起安装时小地图无法正确显示玩家头像）

目前已经有相关的修复方法，而且是从服务端入手的，例如 [Arclight](https://github.com/IzzelAliz/Arclight/blob/7e67d95d4d96d34c563aed7fc8d0a605edab7b68/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/tileentity/SkullTileEntityMixin.java#L47-L55)

所以加了一个配置文件选项 `forceFillSkullNBT`，默认关闭，当打开时使用原版行为，即放置只具有`SkullOwner`属性的头颅会卡顿