### PR TITLE
Fix crash with forge 1.14.2~1.16.2. Upgrade forge maven.

### DIFF
--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -7,6 +7,8 @@ jar {
         ])
     }
     exclude 'net/minecraft/client/renderer/texture/**'
+    exclude 'net/minecraft/client/resources/SkinManager.class'
+    exclude 'net/minecraft/client/resources/SkinManager$ISkinAvailableCallback.class'
     exclude 'net/minecraftforge/**'
 }
 

--- a/Forge/resource/transformers.js
+++ b/Forge/resource/transformers.js
@@ -169,35 +169,6 @@ function initializeCoreMod() {
                 return cn;
             }
         },
-        'SkinAvailableCallbackTransformer': {
-            'target': {
-                'type': 'CLASS',
-                'name': 'net/minecraft/client/resources/SkinManager$SkinAvailableCallback'
-            },
-            'transformer': function (cn) {
-                var mn = new MethodNode(Opcodes.ACC_PUBLIC, mapName("func_180521_a"), "(Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/util/ResourceLocation;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;)V", null, null);
-                if (cn.access === 0) { // 1.14.2+
-                    cn.access = Opcodes.ACC_PUBLIC | Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT;
-
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
-                    mn.instructions.add(new TypeInsnNode(Opcodes.CHECKCAST, "net/minecraft/client/resources/SkinManager$ISkinAvailableCallback"));
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 2));
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 3));
-                    mn.instructions.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, "net/minecraft/client/resources/SkinManager$ISkinAvailableCallback", "onSkinTextureAvailable", "(Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/util/ResourceLocation;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;)V", true));
-                    mn.instructions.add(new InsnNode(Opcodes.RETURN));
-                } else { // 1.13.2
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 2));
-                    mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 3));
-                    mn.instructions.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, "net/minecraft/client/resources/SkinManager$SkinAvailableCallback", "onSkinTextureAvailable", "(Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/util/ResourceLocation;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;)V", true));
-                    mn.instructions.add(new InsnNode(Opcodes.RETURN));
-                }
-                cn.methods.add(mn);
-                return cn;
-            }
-        },
         'ISkinAvailableCallbackTransformer': {
             'target': {
                 'type': 'CLASS',

--- a/Forge/source/net/minecraft/client/resources/SkinManager.java
+++ b/Forge/source/net/minecraft/client/resources/SkinManager.java
@@ -1,0 +1,35 @@
+package net.minecraft.client.resources;
+
+import java.io.File;
+import java.util.Map;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.util.ResourceLocation;
+
+// exclude
+public class SkinManager {
+    public SkinManager(TextureManager textureManagerInstance, File skinCacheDirectory, MinecraftSessionService sessionService) { }
+    public ResourceLocation loadSkin(MinecraftProfileTexture profileTexture, MinecraftProfileTexture.Type textureType) { return null; }
+    public ResourceLocation loadSkin(final MinecraftProfileTexture profileTexture, final MinecraftProfileTexture.Type textureType, final SkinManager.SkinAvailableCallback skinAvailableCallback) { return null; }
+    public void loadProfileTextures(final GameProfile profile, final SkinManager.SkinAvailableCallback skinAvailableCallback, final boolean requireSecure) { }
+    public Map<MinecraftProfileTexture.Type, MinecraftProfileTexture> loadSkinFromCache(GameProfile profile) { return null; }
+
+    // put into mod jar to prevent https://github.com/cpw/modlauncher/issues/39
+    public interface SkinAvailableCallback {
+        default void skinAvailable(MinecraftProfileTexture.Type typeIn, ResourceLocation location, MinecraftProfileTexture profileTexture) {
+            this.onSkinTextureAvailable(typeIn, location, profileTexture);
+        }
+
+        default void onSkinTextureAvailable(MinecraftProfileTexture.Type typeIn, ResourceLocation location, MinecraftProfileTexture profileTexture) {
+            ((SkinManager.ISkinAvailableCallback) this).onSkinTextureAvailable(typeIn, location, profileTexture);
+        }
+    }
+
+    // exclude
+    public interface ISkinAvailableCallback {
+        void onSkinTextureAvailable(MinecraftProfileTexture.Type typeIn, ResourceLocation location, MinecraftProfileTexture profileTexture);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,9 @@ configFile.withReader {
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net/"
         }
         maven {
             name = "sponge"
@@ -63,8 +62,12 @@ subprojects {
 
     repositories {
         maven {
+            name = "forge"
+            url = "https://maven.minecraftforge.net/"
+        }
+        maven {
             name = "sponge"
-            url = "https://repo.spongepowered.org/maven"
+            url = "https://repo.spongepowered.org/repository/maven-public/"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,14 @@ subprojects {
 
     repositories {
         maven {
-            name = "forge"
-            url = "https://maven.minecraftforge.net/"
-        }
-        maven {
             name = "sponge"
             url = "https://repo.spongepowered.org/repository/maven-public/"
+        }
+    }
+
+    repositories.each {
+        if (it instanceof MavenArtifactRepository && it.url.toString() == "https://files.minecraftforge.net/maven") {
+            it.url = "https://maven.minecraftforge.net/"
         }
     }
 


### PR DESCRIPTION
- Fix crash with forge 1.14.2~1.16.2 ( caused by https://github.com/cpw/modlauncher/issues/39, and this prevents the possibility of using SPI in the mod ).

- Forge Maven:
  >Forge has recently reconfigured it's services and no longer permits freely browsing the maven via https://maven.minecraftforge.net/, hence the user/password requirement.
  >
  >Please switch to using https://files.minecraftforge.net/, if you are having issues with ForgeGradle use !fixfg in #tech-support