### PR TITLE
Fix elytra can not be rendered when the cape doesn't contain elytra.

### DIFF
--- a/Common/source/customskinloader/fake/FakeCapeBuffer.java
+++ b/Common/source/customskinloader/fake/FakeCapeBuffer.java
@@ -152,7 +152,6 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
             // NOTICE: OptiFine modified the upload process of the texture from ThreadDownloadImageData
             // Therefore, it may not be correct to simply copy the vanilla behavior
             ((IFakeThreadDownloadImageData) textureObj).resetNewBufferedImage(image.getImage());
-            ((IFakeThreadDownloadImageData) textureObj).resetTextureUploaded();
         }
     }
 

--- a/Common/source/customskinloader/fake/FakeCapeBuffer.java
+++ b/Common/source/customskinloader/fake/FakeCapeBuffer.java
@@ -18,11 +18,11 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
     private static FakeImage elytraImage = loadElytra();
 
     public static FakeImage loadElytra() {
+        loadedGlobal++;
         try {
             InputStream is = MinecraftUtil.getResourceFromResourceLocation(TEXTURE_ELYTRA);
             if (is != null) {
                 FakeImage image = new FakeBufferedImage(ImageIO.read(is));
-                loadedGlobal++;
                 if (image.getWidth() % 64 != 0 || image.getHeight() % 32 != 0) { // wtf?
                     return elytraImage;
                 }
@@ -30,7 +30,6 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
                 return image;
             }
         } catch (IOException ignored) { }
-        loadedGlobal++;
         return null;
     }
 
@@ -53,6 +52,7 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
         if (this.loaded == loadedGlobal) {
             elytraImage = loadElytra();
         }
+        this.loaded = loadedGlobal;
         if (elytraImage != null) {
             if (this.ratioX < 0)
                 this.ratioX = this.image.getWidth() / 64.0D;
@@ -69,7 +69,6 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
                 }
             }
         }
-        this.loaded = loadedGlobal;
         return this.image;
     }
 
@@ -105,7 +104,7 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
                 capeH = elytraH;
                 this.ratioY = capeH / 32.0D;
             }
-            // cape part ((22, 0), (45, 21)) -> (24 * 22)
+            // elytra part ((22, 0), (45, 21)) -> (24 * 22)
             if (elytraW < capeW) {
                 elytraImage = scaleImage(elytraImage, false, capeW / (double) elytraW, 1, elytraW / 64.0D, elytraH / 32.0D, capeW, elytraH, 22, 0, 46, 22);
                 elytraW = capeW;

--- a/Common/source/customskinloader/fake/FakeCapeBuffer.java
+++ b/Common/source/customskinloader/fake/FakeCapeBuffer.java
@@ -155,7 +155,7 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
         }
     }
 
-    //Some cape image doesn't support alpha channel, so reset image format to ARGB
+    // Some cape image doesn't support alpha channel, so reset image format to ARGB
     private static FakeImage resetImageFormat(FakeImage image, int startX, int startY, int endX, int endY) {
         if (image != null) {
             int width = image.getWidth(), height = image.getHeight();
@@ -187,7 +187,7 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
 
         int x0 = (int) (startX * scaleWidth), x1 = (int) ((startX + 1) * scaleWidth), dx0 = x1 - x0;
         for (int x = startX; x < endX; ++x) {
-            int y0 = (int) (startY * scaleWidth), y1 = (int) ((startY + 1) * scaleWidth), dy0 = y1 - y0;
+            int y0 = (int) (startY * scaleHeight), y1 = (int) ((startY + 1) * scaleHeight), dy0 = y1 - y0;
             for (int y = startY; y < endY; ++y) {
                 int rgba = image.getRGBA(x, y);
                 for (int dx = 0; dx < dx0; dx++) {
@@ -195,7 +195,7 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
                         newImage.setRGBA(x0 + dx, y0 + dy, rgba);
                     }
                 }
-                y0 = y1; y1 = (int) ((y + 2) * scaleWidth); dy0 = y1 - y0;
+                y0 = y1; y1 = (int) ((y + 2) * scaleHeight); dy0 = y1 - y0;
             }
             x0 = x1; x1 = (int) ((x + 2) * scaleWidth); dx0 = x1 - x0;
         }

--- a/Common/source/customskinloader/fake/FakeCapeBuffer.java
+++ b/Common/source/customskinloader/fake/FakeCapeBuffer.java
@@ -1,0 +1,208 @@
+package customskinloader.fake;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import javax.imageio.ImageIO;
+
+import customskinloader.fake.itf.IFakeThreadDownloadImageData;
+import customskinloader.fake.texture.FakeBufferedImage;
+import customskinloader.fake.texture.FakeImage;
+import customskinloader.utils.MinecraftUtil;
+import net.minecraft.util.ResourceLocation;
+
+public class FakeCapeBuffer extends FakeSkinBuffer {
+    private static final ResourceLocation TEXTURE_ELYTRA = new ResourceLocation("textures/entity/elytra.png");
+    private static int loadedGlobal = 0;
+    private static FakeImage elytraImage = loadElytra();
+
+    public static FakeImage loadElytra() {
+        try {
+            InputStream is = MinecraftUtil.getResourceFromResourceLocation(TEXTURE_ELYTRA);
+            if (is != null) {
+                FakeImage image = new FakeBufferedImage(ImageIO.read(is));
+                loadedGlobal++;
+                if (image.getWidth() % 64 != 0 || image.getHeight() % 32 != 0) { // wtf?
+                    return elytraImage;
+                }
+                image = resetImageFormat(image, 22, 0, 46, 22);
+                return image;
+            }
+        } catch (IOException ignored) { }
+        loadedGlobal++;
+        return null;
+    }
+
+    private int loaded = 0;
+    private double ratioX = -1;
+    private double ratioY = -1;
+    private ResourceLocation location;
+    private String type = null;
+
+    public FakeCapeBuffer(ResourceLocation location) {
+        this.location = location;
+    }
+
+    @Override
+    public FakeImage parseUserSkin(FakeImage image) {
+        if (image == null) return null;
+        this.image = image;
+
+        // When resource packs were changed, the elytra image needs to be reloaded, and here will be entered again
+        if (this.loaded == loadedGlobal) {
+            elytraImage = loadElytra();
+        }
+        if (elytraImage != null) {
+            if (this.ratioX < 0)
+                this.ratioX = this.image.getWidth() / 64.0D;
+            if (this.ratioY < 0)
+                this.ratioY = this.image.getHeight() / 32.0D;
+            if (this.type == null)
+                this.type = this.judgeType();
+
+            if ("cape".equals(this.type)) {
+                this.image = resetImageFormat(this.image, 0, 0, 22, 17);
+                this.attachElytra(elytraImage);
+                if (this.image instanceof FakeBufferedImage) { // before 1.12.2
+                    this.refreshTexture((FakeBufferedImage) this.image);
+                }
+            }
+        }
+        this.loaded = loadedGlobal;
+        return this.image;
+    }
+
+    /**
+     * Judge the cape type
+     *
+     * @return "elytra" if the cape contains elytra texture, otherwise "cape"
+     */
+    @Override
+    public String judgeType() {
+        if (this.image != null && elytraImage != null) {
+            // If all the pixels in ((22, 0), (45, 21)) is same as background, it means the cape doesn't contain elytra
+            Predicate<Integer> predicate = EQU_BG.apply(this.image.getRGBA(this.image.getWidth() - 1, this.image.getHeight() - 1));
+            return withElytraPixels((x, y) -> !predicate.test(this.image.getRGBA(x, y)), "elytra", "cape");
+        }
+        return "cape";
+    }
+
+    private void attachElytra(FakeImage elytraImage) {
+        if (this.image != null) {
+            int capeW = this.image.getWidth(), capeH = this.image.getHeight();
+            int elytraW = elytraImage.getWidth(), elytraH = elytraImage.getHeight();
+
+            // scale cape and elytra to the same size
+            // cape part ((0, 0), (21, 16)) -> (22 * 17)
+            if (capeW < elytraW) {
+                this.image = scaleImage(this.image, true, elytraW / (double) capeW, 1, capeW / 64.0D, capeH / 32.0D, elytraW, capeH, 0, 0, 22, 17);
+                capeW = elytraW;
+                this.ratioX = capeW / 64.0D;
+            }
+            if (capeH < elytraH) {
+                this.image = scaleImage(this.image, true, 1, elytraH / (double) capeH, capeW / 64.0D, capeH / 32.0D, capeW, elytraH, 0, 0, 22, 17);
+                capeH = elytraH;
+                this.ratioY = capeH / 32.0D;
+            }
+            // cape part ((22, 0), (45, 21)) -> (24 * 22)
+            if (elytraW < capeW) {
+                elytraImage = scaleImage(elytraImage, false, capeW / (double) elytraW, 1, elytraW / 64.0D, elytraH / 32.0D, capeW, elytraH, 22, 0, 46, 22);
+                elytraW = capeW;
+            }
+            if (elytraH < capeH) {
+                elytraImage = scaleImage(elytraImage, false, 1, capeH / (double) elytraH, elytraW / 64.0D, elytraH / 32.0D, elytraW, capeH, 22, 0, 46, 22);
+                elytraH = capeH;
+            }
+
+            // Overwrite pixels from elytra to cape
+            FakeImage finalElytraImage = elytraImage;
+            withElytraPixels((x, y) -> {
+                this.image.setRGBA(x, y, finalElytraImage.getRGBA(x, y));
+                return false;
+            }, null, null);
+        }
+    }
+
+    /**
+     * Traverse every elytra pixel
+     * @param predicate the predicate with x and y
+     * @param returnValue if the condition flag equals the condition, then return this value
+     * @param defaultReturnValue otherwise return this value
+     */
+    private <R> R withElytraPixels(BiPredicate<Integer, Integer> predicate, R returnValue, R defaultReturnValue) {
+        int startX = (int) Math.ceil(22 * ratioX), endX = (int) Math.ceil(46 * ratioX);
+        int startY = (int) Math.ceil(0  * ratioY), endY = (int) Math.ceil(22 * ratioY);
+        int excludeX0 = (int) Math.ceil(24 * ratioX), excludeX1 = (int) Math.ceil(44 * ratioX);
+        int excludeY  = (int) Math.ceil(2  * ratioY);
+        for (int x = startX; x < endX; ++x) {
+            for (int y = startY; y < endY; ++y) {
+                if (y < excludeY && (x < excludeX0 || x >= excludeX1)) continue;
+                if (predicate.test(x, y)) {
+                    return returnValue;
+                }
+            }
+        }
+        return defaultReturnValue;
+    }
+
+    // TextureID won't be regenerated when changing resource packs before 1.12.2
+    private void refreshTexture(FakeBufferedImage image) {
+        Object textureObj = MinecraftUtil.getTextureManager().getTexture(this.location);
+        if (textureObj instanceof IFakeThreadDownloadImageData) {
+            // NOTICE: OptiFine modified the upload process of the texture from ThreadDownloadImageData
+            // Therefore, it may not be correct to simply copy the vanilla behavior
+            ((IFakeThreadDownloadImageData) textureObj).resetNewBufferedImage(image.getImage());
+            ((IFakeThreadDownloadImageData) textureObj).resetTextureUploaded();
+        }
+    }
+
+    //Some cape image doesn't support alpha channel, so reset image format to ARGB
+    private static FakeImage resetImageFormat(FakeImage image, int startX, int startY, int endX, int endY) {
+        if (image != null) {
+            int width = image.getWidth(), height = image.getHeight();
+            image = scaleImage(image, true, 1, 1, width / 64.0D, height / 32.0D, width, height, startX, startY, endX, endY);
+        }
+        return image;
+    }
+
+    /**
+     * Scale image
+     * @param image the image to scale.
+     * @param closeOldImage whether close old image
+     * @param scaleWidth width enlargement ratio
+     * @param scaleHeight height enlargement ratio
+     * @param ratioX the ratio of 64 of the old image width
+     * @param ratioY the ratio of 32 of the old image height
+     * @param width the width after scaling.
+     * @param height the height after scaling.
+     * @param startX the x where start to copy.
+     * @param startY the y where start to copy.
+     * @param endX the x where end to copy.
+     * @param endY the y where end to copy.
+     * @return the image after scaling.
+     */
+    private static FakeImage scaleImage(FakeImage image, boolean closeOldImage, double scaleWidth, double scaleHeight, double ratioX, double ratioY, int width, int height, int startX, int startY, int endX, int endY) {
+        FakeImage newImage = image.createImage(width, height);
+        startX = (int) (startX * ratioX); endX = (int) (endX * ratioX);
+        startY = (int) (startY * ratioY); endY = (int) (endY * ratioY);
+
+        int x0 = (int) (startX * scaleWidth), x1 = (int) ((startX + 1) * scaleWidth), dx0 = x1 - x0;
+        for (int x = startX; x < endX; ++x) {
+            int y0 = (int) (startY * scaleWidth), y1 = (int) ((startY + 1) * scaleWidth), dy0 = y1 - y0;
+            for (int y = startY; y < endY; ++y) {
+                int rgba = image.getRGBA(x, y);
+                for (int dx = 0; dx < dx0; dx++) {
+                    for (int dy = 0; dy < dy0; dy++) {
+                        newImage.setRGBA(x0 + dx, y0 + dy, rgba);
+                    }
+                }
+                y0 = y1; y1 = (int) ((y + 2) * scaleWidth); dy0 = y1 - y0;
+            }
+            x0 = x1; x1 = (int) ((x + 2) * scaleWidth); dx0 = x1 - x0;
+        }
+        if (closeOldImage)
+            image.close();
+        return newImage;
+    }
+}

--- a/Common/source/customskinloader/fake/FakeSkinBuffer.java
+++ b/Common/source/customskinloader/fake/FakeSkinBuffer.java
@@ -16,11 +16,11 @@ public class FakeSkinBuffer implements IImageBuffer {
     FakeImage image = null;
 
     //parseUserSkin for 1.15+
-    public static NativeImage processLegacySkin(NativeImage image, Runnable processTask) {
+    public static NativeImage processLegacySkin(NativeImage image, Runnable processTask, Function<NativeImage, NativeImage> processLegacySkin) {
         if (processTask instanceof IImageBuffer) {
             return ((IImageBuffer) processTask).func_195786_a(image);
         }
-        return new FakeSkinBuffer().func_195786_a(image);
+        return processLegacySkin.apply(image);
     }
 
     //parseUserSkin for 1.13+

--- a/Common/source/customskinloader/fake/FakeSkinBuffer.java
+++ b/Common/source/customskinloader/fake/FakeSkinBuffer.java
@@ -1,6 +1,7 @@
 package customskinloader.fake;
 
 import java.awt.image.BufferedImage;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import customskinloader.CustomSkinLoader;
@@ -12,7 +13,7 @@ import net.minecraft.client.renderer.texture.NativeImage;
 
 public class FakeSkinBuffer implements IImageBuffer {
     private int ratio = 1;
-    private FakeImage image = null;
+    FakeImage image = null;
 
     //parseUserSkin for 1.15+
     public static NativeImage processLegacySkin(NativeImage image, Runnable processTask) {
@@ -94,6 +95,9 @@ public class FakeSkinBuffer implements IImageBuffer {
         return image;
     }
 
+    /** Judge if the color is transparent or same with background */
+    static final Function<Integer, Predicate<Integer>> EQU_BG = bgColor -> getA(bgColor) == 0 ? (c) -> getA(c) == 0 : (c) -> c.equals(bgColor);
+
     /**
      * Judge the type of skin
      * Must be called after parseUserSkin
@@ -112,8 +116,7 @@ public class FakeSkinBuffer implements IImageBuffer {
          * which means it is Alex model.
          * Otherwise, it is Steve model.
          * */
-        Predicate<Integer> predicate =
-                getA(bgColor) == 0 ? (c) -> getA(c) == 0 : (c) -> c == bgColor;
+        Predicate<Integer> predicate = EQU_BG.apply(bgColor);
         for (int x = 54 * ratio; x <= 55 * ratio; ++x) {
             for (int y = 20 * ratio; y <= 31 * ratio; ++y) {
                 int color = image.getRGBA(x, y);

--- a/Common/source/customskinloader/fake/FakeSkinManager.java
+++ b/Common/source/customskinloader/fake/FakeSkinManager.java
@@ -105,7 +105,10 @@ public class FakeSkinManager {
         private MinecraftProfileTexture texture;
 
         public BaseBuffer(SkinAvailableCallback callback, Type type, ResourceLocation location, MinecraftProfileTexture texture) {
-            this.buffer = (type == Type.SKIN ? new FakeSkinBuffer() : null);
+            switch (type) {
+                case SKIN: this.buffer = new FakeSkinBuffer(); break;
+                case CAPE: this.buffer = new FakeCapeBuffer(location); break;
+            }
 
             this.callback = callback;
             this.type = type;
@@ -118,7 +121,7 @@ public class FakeSkinManager {
         }
 
         public BufferedImage parseUserSkin(BufferedImage image) {
-            return buffer == null ? image : buffer.parseUserSkin(image);
+            return buffer instanceof FakeSkinBuffer ? ((FakeSkinBuffer) buffer).parseUserSkin(image) : image;
         }
 
         public void skinAvailable() {

--- a/Common/source/customskinloader/fake/FakeThreadDownloadImageData.java
+++ b/Common/source/customskinloader/fake/FakeThreadDownloadImageData.java
@@ -84,7 +84,7 @@ public class FakeThreadDownloadImageData {
         V4(() -> new IThreadDownloadImageDataBuilder() { // Forge 1.15.x~1.16.x
             @Override
             public SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType) {
-                return new DownloadingTexture(cacheFile, imageUrl, textureResourceLocation, textureType != MinecraftProfileTexture.Type.ELYTRA, imageBuffer);
+                return new DownloadingTexture(cacheFile, imageUrl, textureResourceLocation, true, imageBuffer);
             }
         });
 

--- a/Common/source/customskinloader/fake/FakeThreadDownloadImageData.java
+++ b/Common/source/customskinloader/fake/FakeThreadDownloadImageData.java
@@ -84,7 +84,7 @@ public class FakeThreadDownloadImageData {
         V4(() -> new IThreadDownloadImageDataBuilder() { // Forge 1.15.x~1.16.x
             @Override
             public SimpleTexture build(File cacheFile, String imageUrl, ResourceLocation textureResourceLocation, IImageBuffer imageBuffer, MinecraftProfileTexture.Type textureType) {
-                return new DownloadingTexture(cacheFile, imageUrl, textureResourceLocation, textureType == MinecraftProfileTexture.Type.SKIN, imageBuffer);
+                return new DownloadingTexture(cacheFile, imageUrl, textureResourceLocation, textureType != MinecraftProfileTexture.Type.ELYTRA, imageBuffer);
             }
         });
 

--- a/Common/source/customskinloader/fake/itf/IFakeMinecraft.java
+++ b/Common/source/customskinloader/fake/itf/IFakeMinecraft.java
@@ -1,8 +1,17 @@
 package customskinloader.fake.itf;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import net.minecraft.client.Minecraft;
+import net.minecraft.util.ResourceLocation;
 
 public interface IFakeMinecraft {
+    default InputStream getResourceFromResourceLocation(ResourceLocation location) throws IOException {
+        return ((Minecraft) this).getResourceManager().getResource(location).getInputStream();
+    }
+
+    // 1.14+
     default void execute(Runnable runnable) {
         ((Minecraft) this).addScheduledTask(runnable);
     }

--- a/Common/source/customskinloader/fake/itf/IFakeThreadDownloadImageData.java
+++ b/Common/source/customskinloader/fake/itf/IFakeThreadDownloadImageData.java
@@ -5,12 +5,8 @@ import java.awt.image.BufferedImage;
 // This interface is only available before 1.12.2
 public interface IFakeThreadDownloadImageData {
     /**
-     * Reset {@link net.minecraft.client.renderer.ThreadDownloadImageData#textureUploaded} to false to refresh texture.
-     */
-    void resetTextureUploaded();
-
-    /**
-     * Reset {@link net.minecraft.client.renderer.ThreadDownloadImageData#bufferedImage}.
+     * Reset {@link net.minecraft.client.renderer.ThreadDownloadImageData#bufferedImage} and
+     * {@link net.minecraft.client.renderer.ThreadDownloadImageData#textureUploaded} to false to refresh texture.
      */
     void resetNewBufferedImage(BufferedImage image);
 }

--- a/Common/source/customskinloader/fake/itf/IFakeThreadDownloadImageData.java
+++ b/Common/source/customskinloader/fake/itf/IFakeThreadDownloadImageData.java
@@ -1,0 +1,16 @@
+package customskinloader.fake.itf;
+
+import java.awt.image.BufferedImage;
+
+// This interface is only available before 1.12.2
+public interface IFakeThreadDownloadImageData {
+    /**
+     * Reset {@link net.minecraft.client.renderer.ThreadDownloadImageData#textureUploaded} to false to refresh texture.
+     */
+    void resetTextureUploaded();
+
+    /**
+     * Reset {@link net.minecraft.client.renderer.ThreadDownloadImageData#bufferedImage}.
+     */
+    void resetNewBufferedImage(BufferedImage image);
+}

--- a/Common/source/customskinloader/fake/texture/FakeNativeImage.java
+++ b/Common/source/customskinloader/fake/texture/FakeNativeImage.java
@@ -30,11 +30,14 @@ public class FakeNativeImage implements FakeImage {
     }
 
     public int getRGBA(int x, int y) {
-        return image.func_195709_a(x, y);
+        int abgr = image.func_195709_a(x, y);
+        int b = abgr >>> 16 & 0xFF, r = abgr >>> 0 & 0xFF;
+        return abgr & 0xFF00FF00 | (r << 16 | b);
     }
 
     public void setRGBA(int x, int y, int rgba) {
-        image.func_195700_a(x, y, rgba);
+        int b = rgba >>> 0 & 0xFF, r = rgba >>> 16 & 0xFF;
+        image.func_195700_a(x, y, rgba & 0xFF00FF00 | (b << 16 | r));
     }
 
     public void copyImageData(FakeImage image) {

--- a/Common/source/customskinloader/utils/MinecraftUtil.java
+++ b/Common/source/customskinloader/utils/MinecraftUtil.java
@@ -1,6 +1,8 @@
 package customskinloader.utils;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -8,9 +10,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.mojang.authlib.GameProfile;
+import customskinloader.fake.itf.IFakeMinecraft;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.resources.SkinManager;
+import net.minecraft.util.ResourceLocation;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -28,6 +32,10 @@ public class MinecraftUtil {
 
     public static SkinManager getSkinManager() {
         return Minecraft.getMinecraft().getSkinManager();
+    }
+
+    public static InputStream getResourceFromResourceLocation(ResourceLocation location) throws IOException {
+        return ((IFakeMinecraft) Minecraft.getMinecraft()).getResourceFromResourceLocation(location);
     }
 
 

--- a/Fabric/Fabric.tsrg
+++ b/Fabric/Fabric.tsrg
@@ -9,6 +9,7 @@ net/minecraft/client/Minecraft net/minecraft/class_310
 	addScheduledTask (Ljava/lang/Runnable;)Lcom/google/common/util/concurrent/ListenableFuture; func_152344_a
 	getCurrentServerData ()Lnet/minecraft/client/multiplayer/ServerData; method_1558
 	getMinecraft ()Lnet/minecraft/client/Minecraft; method_1551
+	getResourceManager ()Lnet/minecraft/client/resources/IResourceManager; method_1478
 	getSession ()Lnet/minecraft/util/Session; method_1548
 	getSessionService ()Lcom/mojang/authlib/minecraft/MinecraftSessionService; method_1495
 	getSkinManager ()Lnet/minecraft/client/resources/SkinManager; method_1582
@@ -45,6 +46,10 @@ net/minecraft/client/renderer/texture/ThreadDownloadImageData net/minecraft/clas
 net/minecraft/client/resources/DefaultPlayerSkin net/minecraft/class_1068
 	getDefaultSkin (Ljava/util/UUID;)Lnet/minecraft/util/ResourceLocation; method_4648
 	getDefaultSkinLegacy ()Lnet/minecraft/util/ResourceLocation; method_4649
+net/minecraft/client/resources/IResource net/minecraft/class_3298
+	getInputStream ()Ljava/io/InputStream; method_14482
+net/minecraft/client/resources/IResourceManager net/minecraft/class_3300
+	getResource (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/resources/IResource; method_14486
 net/minecraft/client/resources/SkinManager net/minecraft/class_1071
 	loadProfileTextures (Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/resources/SkinManager$SkinAvailableCallback;Z)V method_4652
 net/minecraft/client/resources/SkinManager$SkinAvailableCallback net/minecraft/class_1071$class_1072

--- a/Fabric/mixin.tsrg
+++ b/Fabric/mixin.tsrg
@@ -12,6 +12,8 @@ net/minecraft/client/renderer/IRenderTypeBuffer net/minecraft/class_4597
 net/minecraft/client/renderer/RenderType net/minecraft/class_1921
 	getEntitySolid (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType; method_23572
 net/minecraft/client/renderer/ThreadDownloadImageData net/minecraft/class_1046
+	bufferedImage field_110560_d
+	textureUploaded field_5215
 	processTask field_20843
 	loadTexture (Ljava/io/InputStream;)Lnet/minecraft/client/renderer/texture/NativeImage; method_22795
 	processLegacySkin (Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage; method_22798

--- a/Fabric/resource/mixins.customskinloader.json
+++ b/Fabric/resource/mixins.customskinloader.json
@@ -9,7 +9,7 @@
     "MixinRenderPlayer",
     "MixinSkinManager",
     "MixinTextureManager",
-    "MixinThreadDownloadImageData",
+    "MixinThreadDownloadImageDataV2",
     "MixinTileEntitySkull"
   ],
   "refmap": "mixins.customskinloader.refmap.json",

--- a/Fabric/source/customskinloader/fabric/MixinConfigPlugin.java
+++ b/Fabric/source/customskinloader/fabric/MixinConfigPlugin.java
@@ -54,7 +54,7 @@ public class MixinConfigPlugin implements IMixinConfigPlugin {
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         boolean result = true;
-        if (mixinClassName.endsWith(".MixinThreadDownloadImageData")) {
+        if (mixinClassName.endsWith(".MixinThreadDownloadImageDataV2")) {
             result = this.world_version >= 2205 && this.protocol_version >= 554; // 19w38a+
         } else if (mixinClassName.endsWith(".MixinLayerCape") || mixinClassName.endsWith(".MixinRenderPlayer")) {
             result = this.world_version >= 2210 && this.protocol_version >= 558; // 19w41a+

--- a/Forge/resource/transformers.js
+++ b/Forge/resource/transformers.js
@@ -17,8 +17,9 @@ function checkName(name, srgName) {
 // De-obfuscate method and field names.
 function mapName(srgName) {
     try {
-        if (srgName.startsWith("field_")) return net.minecraftforge.coremod.api.ASMAPI.mapField(srgName);
-        if (srgName.startsWith("func_")) return net.minecraftforge.coremod.api.ASMAPI.mapMethod(srgName);
+        var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI');
+        if (srgName.startsWith("field_")) return ASMAPI.mapField(srgName);
+        if (srgName.startsWith("func_")) return ASMAPI.mapMethod(srgName);
     } catch (ignored) {
         // Before forge-1.13.2-25.0.194
     }
@@ -166,6 +167,16 @@ function initializeCoreMod() {
             },
             'transformer': function (cn) {
                 cn.interfaces.add("customskinloader/fake/itf/IFakeMinecraft");
+
+                var mn = new MethodNode(Opcodes.ACC_PUBLIC, "getResourceFromResourceLocation", "(Lnet/minecraft/util/ResourceLocation;)Ljava/io/InputStream;", null, null);
+                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                mn.instructions.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/Minecraft", mapName("func_195551_G"), "()Lnet/minecraft/resources/IResourceManager;", false));
+                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                mn.instructions.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, "net/minecraft/resources/IResourceManager", mapName("func_199002_a"), "(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/resources/IResource;", true));
+                mn.instructions.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, "net/minecraft/resources/IResource", mapName("func_199027_b"), "()Ljava/io/InputStream;", true));
+                mn.instructions.add(new InsnNode(Opcodes.ARETURN));
+                cn.methods.add(mn);
+
                 return cn;
             }
         },

--- a/Forge/resource/transformers.js
+++ b/Forge/resource/transformers.js
@@ -1,7 +1,10 @@
+var Handle = Java.type('org.objectweb.asm.Handle');
 var Opcodes = Java.type('org.objectweb.asm.Opcodes');
+var Type = Java.type('org.objectweb.asm.Type');
 var FieldInsnNode = Java.type('org.objectweb.asm.tree.FieldInsnNode');
 var FieldNode = Java.type('org.objectweb.asm.tree.FieldNode');
 var InsnNode = Java.type('org.objectweb.asm.tree.InsnNode');
+var InvokeDynamicInsnNode = Java.type('org.objectweb.asm.tree.InvokeDynamicInsnNode');
 var JumpInsnNode = Java.type('org.objectweb.asm.tree.JumpInsnNode');
 var LabelNode = Java.type('org.objectweb.asm.tree.LabelNode');
 var MethodInsnNode = Java.type('org.objectweb.asm.tree.MethodInsnNode');
@@ -214,9 +217,15 @@ function initializeCoreMod() {
                         for (var iterator = mn.instructions.iterator(); iterator.hasNext();) {
                             var node = iterator.next();
                             if (node.getOpcode() === Opcodes.INVOKESTATIC && node.owner.equals("net/minecraft/client/renderer/texture/DownloadingTexture") && checkName(node.name, "func_229163_c_") && node.desc.equals("(Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage;")) {
+                                // FakeSkinBuffer.processLegacySkin(image, this.processTask, DownloadingTexture::processLegacySkin);
                                 mn.instructions.insertBefore(node, new VarInsnNode(Opcodes.ALOAD, 0));
                                 mn.instructions.insertBefore(node, new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/texture/DownloadingTexture", mapName("field_229155_i_"), "Ljava/lang/Runnable;"));
-                                iterator.set(new MethodInsnNode(Opcodes.INVOKESTATIC, "customskinloader/fake/FakeSkinBuffer", "processLegacySkin", "(Lnet/minecraft/client/renderer/texture/NativeImage;Ljava/lang/Runnable;)Lnet/minecraft/client/renderer/texture/NativeImage;", false));
+                                mn.instructions.insertBefore(node, new InvokeDynamicInsnNode("apply", "()Ljava/util/function/Function;",
+                                    /*   bsm   */ new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "metafactory", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", false),
+                                    /* bsmArgs */ Type.getType("(Ljava/lang/Object;)Ljava/lang/Object;"),
+                                    /* bsmArgs */ new Handle(Opcodes.H_INVOKESTATIC, "net/minecraft/client/renderer/texture/DownloadingTexture", mapName("func_229163_c_"), "(Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage;", false),
+                                    /* bsmArgs */ Type.getType("(Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage;")));
+                                iterator.set(new MethodInsnNode(Opcodes.INVOKESTATIC, "customskinloader/fake/FakeSkinBuffer", "processLegacySkin", "(Lnet/minecraft/client/renderer/texture/NativeImage;Ljava/lang/Runnable;Ljava/util/function/Function;)Lnet/minecraft/client/renderer/texture/NativeImage;", false));
                             }
                         }
                     }

--- a/Forge/source/customskinloader/forge/TransformerManager.java
+++ b/Forge/source/customskinloader/forge/TransformerManager.java
@@ -44,6 +44,10 @@ public class TransformerManager {
         return remapper.mapType(name);
     }
 
+    public static String mapFieldName(String owner, String name, String desc) {
+        return remapper.mapFieldName(owner, name, desc);
+    }
+
     public static String mapMethodName(String owner, String name, String desc) {
         return remapper.mapMethodName(owner, name, desc);
     }

--- a/Forge/source/customskinloader/forge/loader/LaunchWrapper.java
+++ b/Forge/source/customskinloader/forge/loader/LaunchWrapper.java
@@ -19,7 +19,8 @@ import org.objectweb.asm.tree.MethodNode;
 public class LaunchWrapper implements IClassTransformer {
     private static final TransformerManager.IClassTransformer[] CLASS_TRANSFORMERS = {
         new FakeInterfacesTransformer.MinecraftTransformer(),
-        new FakeInterfacesTransformer.AbstractTextureTransfomer(),
+        new FakeInterfacesTransformer.ThreadDownloadImageDataTransformer(),
+        new FakeInterfacesTransformer.AbstractTextureTransformer(),
         new FakeInterfacesTransformer.TextureTransformer(),
         new FakeInterfacesTransformer.TextureManagerTransformer()
     };

--- a/Forge/source/customskinloader/forge/transformer/FakeInterfacesTransformer.java
+++ b/Forge/source/customskinloader/forge/transformer/FakeInterfacesTransformer.java
@@ -3,6 +3,10 @@ package customskinloader.forge.transformer;
 import customskinloader.forge.TransformerManager;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
 
 public class FakeInterfacesTransformer {
     @TransformerManager.TransformTarget(
@@ -17,9 +21,38 @@ public class FakeInterfacesTransformer {
     }
 
     @TransformerManager.TransformTarget(
+        className = "net.minecraft.client.renderer.ThreadDownloadImageData"
+    )
+    public static class ThreadDownloadImageDataTransformer implements TransformerManager.IClassTransformer {
+        @Override
+        public ClassNode transform(ClassNode cn) {
+            cn.interfaces.add("customskinloader/fake/itf/IFakeThreadDownloadImageData");
+
+            {
+                MethodNode mn = new MethodNode(Opcodes.ACC_PUBLIC, "resetTextureUploaded", "()V", null, null);
+                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                mn.instructions.add(new InsnNode(Opcodes.ICONST_0));
+                mn.instructions.add(new FieldInsnNode(Opcodes.PUTFIELD, cn.name, TransformerManager.mapFieldName(cn.name, "field_110559_g", "Z"), "Z"));
+                mn.instructions.add(new InsnNode(Opcodes.RETURN));
+                cn.methods.add(mn);
+            }
+            {
+                MethodNode mn = new MethodNode(Opcodes.ACC_PUBLIC, "resetNewBufferedImage", "(Ljava/awt/image/BufferedImage;)V", null, null);
+                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                mn.instructions.add(new FieldInsnNode(Opcodes.PUTFIELD, cn.name, TransformerManager.mapFieldName(cn.name, "field_110560_d", "Ljava/awt/image/BufferedImage;"), "Ljava/awt/image/BufferedImage;"));
+                mn.instructions.add(new InsnNode(Opcodes.RETURN));
+                cn.methods.add(mn);
+            }
+
+            return cn;
+        }
+    }
+
+    @TransformerManager.TransformTarget(
         className = "net.minecraft.client.renderer.texture.AbstractTexture"
     )
-    public static class AbstractTextureTransfomer implements TransformerManager.IClassTransformer {
+    public static class AbstractTextureTransformer implements TransformerManager.IClassTransformer {
         @Override
         public ClassNode transform(ClassNode cn) {
             cn.interfaces.add("net/minecraft/client/renderer/texture/Texture");

--- a/Forge/source/customskinloader/forge/transformer/FakeInterfacesTransformer.java
+++ b/Forge/source/customskinloader/forge/transformer/FakeInterfacesTransformer.java
@@ -28,22 +28,15 @@ public class FakeInterfacesTransformer {
         public ClassNode transform(ClassNode cn) {
             cn.interfaces.add("customskinloader/fake/itf/IFakeThreadDownloadImageData");
 
-            {
-                MethodNode mn = new MethodNode(Opcodes.ACC_PUBLIC, "resetTextureUploaded", "()V", null, null);
-                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
-                mn.instructions.add(new InsnNode(Opcodes.ICONST_0));
-                mn.instructions.add(new FieldInsnNode(Opcodes.PUTFIELD, cn.name, TransformerManager.mapFieldName(cn.name, "field_110559_g", "Z"), "Z"));
-                mn.instructions.add(new InsnNode(Opcodes.RETURN));
-                cn.methods.add(mn);
-            }
-            {
-                MethodNode mn = new MethodNode(Opcodes.ACC_PUBLIC, "resetNewBufferedImage", "(Ljava/awt/image/BufferedImage;)V", null, null);
-                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
-                mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
-                mn.instructions.add(new FieldInsnNode(Opcodes.PUTFIELD, cn.name, TransformerManager.mapFieldName(cn.name, "field_110560_d", "Ljava/awt/image/BufferedImage;"), "Ljava/awt/image/BufferedImage;"));
-                mn.instructions.add(new InsnNode(Opcodes.RETURN));
-                cn.methods.add(mn);
-            }
+            MethodNode mn = new MethodNode(Opcodes.ACC_PUBLIC, "resetNewBufferedImage", "(Ljava/awt/image/BufferedImage;)V", null, null);
+            mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+            mn.instructions.add(new InsnNode(Opcodes.ICONST_0));
+            mn.instructions.add(new FieldInsnNode(Opcodes.PUTFIELD, cn.name, TransformerManager.mapFieldName(cn.name, "field_110559_g", "Z"), "Z"));
+            mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
+            mn.instructions.add(new VarInsnNode(Opcodes.ALOAD, 1));
+            mn.instructions.add(new FieldInsnNode(Opcodes.PUTFIELD, cn.name, TransformerManager.mapFieldName(cn.name, "field_110560_d", "Ljava/awt/image/BufferedImage;"), "Ljava/awt/image/BufferedImage;"));
+            mn.instructions.add(new InsnNode(Opcodes.RETURN));
+            cn.methods.add(mn);
 
             return cn;
         }

--- a/Vanilla/1.12.2/1.12.2.tsrg
+++ b/Vanilla/1.12.2/1.12.2.tsrg
@@ -9,6 +9,7 @@ net/minecraft/client/Minecraft bib
 	addScheduledTask (Ljava/lang/Runnable;)Lcom/google/common/util/concurrent/ListenableFuture; a
 	getCurrentServerData ()Lnet/minecraft/client/multiplayer/ServerData; C
 	getMinecraft ()Lnet/minecraft/client/Minecraft; z
+	getResourceManager ()Lnet/minecraft/client/resources/IResourceManager; O
 	getSession ()Lnet/minecraft/util/Session; K
 	getSessionService ()Lcom/mojang/authlib/minecraft/MinecraftSessionService; X
 	getSkinManager ()Lnet/minecraft/client/resources/SkinManager; Y
@@ -45,6 +46,10 @@ net/minecraft/client/renderer/texture/ThreadDownloadImageData cdh
 net/minecraft/client/resources/DefaultPlayerSkin cef
 	getDefaultSkin (Ljava/util/UUID;)Lnet/minecraft/util/ResourceLocation; a
 	getDefaultSkinLegacy ()Lnet/minecraft/util/ResourceLocation; a
+net/minecraft/client/resources/IResource ceo
+	getInputStream ()Ljava/io/InputStream; b
+net/minecraft/client/resources/IResourceManager cep
+	getResource (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/resources/IResource; a
 net/minecraft/client/resources/SkinManager cex
 	loadProfileTextures (Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/resources/SkinManager$SkinAvailableCallback;Z)V a
 net/minecraft/client/resources/SkinManager$SkinAvailableCallback cex$a

--- a/Vanilla/1.12.2/mixin.tsrg
+++ b/Vanilla/1.12.2/mixin.tsrg
@@ -12,6 +12,8 @@ net/minecraft/client/model/ModelRenderer brs
 net/minecraft/client/renderer/RenderType net/minecraft/client/renderer/RenderType
 	getEntitySolid (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType; func_228634_a_
 net/minecraft/client/renderer/ThreadDownloadImageData cdh
+	bufferedImage l
+	textureUploaded n
 	processTask field_229155_i_
 	loadTexture (Ljava/io/InputStream;)Lnet/minecraft/client/renderer/texture/NativeImage; func_229159_a_
 	processLegacySkin (Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage; func_229163_c_

--- a/Vanilla/1.12.2/resource/mixins.customskinloader.json
+++ b/Vanilla/1.12.2/resource/mixins.customskinloader.json
@@ -8,6 +8,7 @@
     "MixinPlayerMenuObject",
     "MixinSkinManager",
     "MixinTextureManager",
+    "MixinThreadDownloadImageDataV1",
     "MixinTileEntitySkull"
   ],
   "refmap": "mixins.customskinloader.refmap.json",

--- a/Vanilla/1.15.2/1.15.2.tsrg
+++ b/Vanilla/1.15.2/1.15.2.tsrg
@@ -9,6 +9,7 @@ net/minecraft/client/Minecraft dbn
 	addScheduledTask (Ljava/lang/Runnable;)Lcom/google/common/util/concurrent/ListenableFuture; func_152344_a
 	getCurrentServerData ()Lnet/minecraft/client/multiplayer/ServerData; z
 	getMinecraft ()Lnet/minecraft/client/Minecraft; x
+	getResourceManager ()Lnet/minecraft/client/resources/IResourceManager; I
 	getSession ()Lnet/minecraft/util/Session; E
 	getSessionService ()Lcom/mojang/authlib/minecraft/MinecraftSessionService; R
 	getSkinManager ()Lnet/minecraft/client/resources/SkinManager; S
@@ -45,6 +46,10 @@ net/minecraft/client/renderer/texture/ThreadDownloadImageData dzz
 net/minecraft/client/resources/DefaultPlayerSkin eaq
 	getDefaultSkin (Ljava/util/UUID;)Lnet/minecraft/util/ResourceLocation; a
 	getDefaultSkinLegacy ()Lnet/minecraft/util/ResourceLocation; a
+net/minecraft/client/resources/IResource za
+	getInputStream ()Ljava/io/InputStream; b
+net/minecraft/client/resources/IResourceManager zb
+	getResource (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/resources/IResource; a
 net/minecraft/client/resources/SkinManager eaz
 	loadProfileTextures (Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/resources/SkinManager$SkinAvailableCallback;Z)V a
 net/minecraft/client/resources/SkinManager$SkinAvailableCallback eaz$a

--- a/Vanilla/1.15.2/mixin.tsrg
+++ b/Vanilla/1.15.2/mixin.tsrg
@@ -12,6 +12,8 @@ net/minecraft/client/renderer/IRenderTypeBuffer dqt
 net/minecraft/client/renderer/RenderType drb
 	getEntitySolid (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType; a
 net/minecraft/client/renderer/ThreadDownloadImageData dzz
+	bufferedImage field_110560_d
+	textureUploaded k
 	processTask i
 	loadTexture (Ljava/io/InputStream;)Lnet/minecraft/client/renderer/texture/NativeImage; a
 	processLegacySkin (Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage; c

--- a/Vanilla/1.15.2/resource/mixins.customskinloader.json
+++ b/Vanilla/1.15.2/resource/mixins.customskinloader.json
@@ -9,7 +9,7 @@
     "MixinRenderPlayer",
     "MixinSkinManager",
     "MixinTextureManager",
-    "MixinThreadDownloadImageData",
+    "MixinThreadDownloadImageDataV2",
     "MixinTileEntitySkull"
   ],
   "refmap": "mixins.customskinloader.refmap.json",

--- a/Vanilla/1.16.5/1.16.5.tsrg
+++ b/Vanilla/1.16.5/1.16.5.tsrg
@@ -9,6 +9,7 @@ net/minecraft/client/Minecraft djz
 	addScheduledTask (Ljava/lang/Runnable;)Lcom/google/common/util/concurrent/ListenableFuture; func_152344_a
 	getCurrentServerData ()Lnet/minecraft/client/multiplayer/ServerData; E
 	getMinecraft ()Lnet/minecraft/client/Minecraft; C
+	getResourceManager ()Lnet/minecraft/client/resources/IResourceManager; N
 	getSession ()Lnet/minecraft/util/Session; J
 	getSessionService ()Lcom/mojang/authlib/minecraft/MinecraftSessionService; Y
 	getSkinManager ()Lnet/minecraft/client/resources/SkinManager; Z
@@ -45,6 +46,10 @@ net/minecraft/client/renderer/texture/ThreadDownloadImageData ejt
 net/minecraft/client/resources/DefaultPlayerSkin ekj
 	getDefaultSkin (Ljava/util/UUID;)Lnet/minecraft/util/ResourceLocation; a
 	getDefaultSkinLegacy ()Lnet/minecraft/util/ResourceLocation; a
+net/minecraft/client/resources/IResource acg
+	getInputStream ()Ljava/io/InputStream; b
+net/minecraft/client/resources/IResourceManager ach
+	getResource (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/resources/IResource; a
 net/minecraft/client/resources/SkinManager eks
 	loadProfileTextures (Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/resources/SkinManager$SkinAvailableCallback;Z)V a
 net/minecraft/client/resources/SkinManager$SkinAvailableCallback eks$a

--- a/Vanilla/1.16.5/mixin.tsrg
+++ b/Vanilla/1.16.5/mixin.tsrg
@@ -12,6 +12,8 @@ net/minecraft/client/renderer/IRenderTypeBuffer eag
 net/minecraft/client/renderer/RenderType eao
 	getEntitySolid (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType; b
 net/minecraft/client/renderer/ThreadDownloadImageData ejt
+	bufferedImage field_110560_d
+	textureUploaded k
 	processTask i
 	loadTexture (Ljava/io/InputStream;)Lnet/minecraft/client/renderer/texture/NativeImage; a
 	processLegacySkin (Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage; c

--- a/Vanilla/1.16.5/resource/mixins.customskinloader.json
+++ b/Vanilla/1.16.5/resource/mixins.customskinloader.json
@@ -9,7 +9,7 @@
     "MixinRenderPlayer",
     "MixinSkinManager",
     "MixinTextureManager",
-    "MixinThreadDownloadImageData",
+    "MixinThreadDownloadImageDataV2",
     "MixinTileEntitySkull"
   ],
   "refmap": "mixins.customskinloader.refmap.json",

--- a/Vanilla/1.8.9/1.8.9.tsrg
+++ b/Vanilla/1.8.9/1.8.9.tsrg
@@ -9,6 +9,7 @@ net/minecraft/client/Minecraft ave
 	addScheduledTask (Ljava/lang/Runnable;)Lcom/google/common/util/concurrent/ListenableFuture; a
 	getCurrentServerData ()Lnet/minecraft/client/multiplayer/ServerData; D
 	getMinecraft ()Lnet/minecraft/client/Minecraft; A
+	getResourceManager ()Lnet/minecraft/client/resources/IResourceManager; Q
 	getSession ()Lnet/minecraft/util/Session; L
 	getSessionService ()Lcom/mojang/authlib/minecraft/MinecraftSessionService; aa
 	getSkinManager ()Lnet/minecraft/client/resources/SkinManager; ab
@@ -45,6 +46,10 @@ net/minecraft/client/renderer/texture/ThreadDownloadImageData bma
 net/minecraft/client/resources/DefaultPlayerSkin bmz
 	getDefaultSkin (Ljava/util/UUID;)Lnet/minecraft/util/ResourceLocation; a
 	getDefaultSkinLegacy ()Lnet/minecraft/util/ResourceLocation; a
+net/minecraft/client/resources/IResource bnh
+	getInputStream ()Ljava/io/InputStream; b
+net/minecraft/client/resources/IResourceManager bni
+	getResource (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/resources/IResource; a
 net/minecraft/client/resources/SkinManager bnp
 	loadProfileTextures (Lcom/mojang/authlib/GameProfile;Lnet/minecraft/client/resources/SkinManager$SkinAvailableCallback;Z)V a
 net/minecraft/client/resources/SkinManager$SkinAvailableCallback bnp$a

--- a/Vanilla/1.8.9/mixin.tsrg
+++ b/Vanilla/1.8.9/mixin.tsrg
@@ -12,6 +12,8 @@ net/minecraft/client/model/ModelRenderer bct
 net/minecraft/client/renderer/RenderType net/minecraft/client/renderer/RenderType
 	getEntitySolid (Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/RenderType; func_228634_a_
 net/minecraft/client/renderer/ThreadDownloadImageData bma
+	bufferedImage l
+	textureUploaded n
 	processTask field_229155_i_
 	loadTexture (Ljava/io/InputStream;)Lnet/minecraft/client/renderer/texture/NativeImage; func_229159_a_
 	processLegacySkin (Lnet/minecraft/client/renderer/texture/NativeImage;)Lnet/minecraft/client/renderer/texture/NativeImage; func_229163_c_

--- a/Vanilla/1.8.9/resource/mixins.customskinloader.json
+++ b/Vanilla/1.8.9/resource/mixins.customskinloader.json
@@ -8,6 +8,7 @@
     "MixinPlayerMenuObject",
     "MixinSkinManager",
     "MixinTextureManager",
+    "MixinThreadDownloadImageDataV1",
     "MixinTileEntitySkull"
   ],
   "refmap": "mixins.customskinloader.refmap.json",

--- a/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV1.java
+++ b/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV1.java
@@ -1,0 +1,27 @@
+package customskinloader.mixin;
+
+import java.awt.image.BufferedImage;
+
+import customskinloader.fake.itf.IFakeThreadDownloadImageData;
+import net.minecraft.client.renderer.ThreadDownloadImageData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ThreadDownloadImageData.class) // This mixin is only for 1.12.2-
+public abstract class MixinThreadDownloadImageDataV1 implements IFakeThreadDownloadImageData {
+    @Shadow
+    private BufferedImage bufferedImage;
+
+    @Shadow
+    private boolean textureUploaded;
+
+    @Override
+    public void resetTextureUploaded() {
+        this.textureUploaded = false;
+    }
+
+    @Override
+    public void resetNewBufferedImage(BufferedImage image) {
+        this.bufferedImage = image;
+    }
+}

--- a/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV1.java
+++ b/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV1.java
@@ -16,12 +16,8 @@ public abstract class MixinThreadDownloadImageDataV1 implements IFakeThreadDownl
     private boolean textureUploaded;
 
     @Override
-    public void resetTextureUploaded() {
-        this.textureUploaded = false;
-    }
-
-    @Override
     public void resetNewBufferedImage(BufferedImage image) {
+        this.textureUploaded = false;
         this.bufferedImage = image;
     }
 }

--- a/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV2.java
+++ b/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV2.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ThreadDownloadImageData.class)
 @SuppressWarnings("target")
-public abstract class MixinThreadDownloadImageData {
+public abstract class MixinThreadDownloadImageDataV2 {
     @Final
     @Shadow
     private Runnable processTask;

--- a/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV2.java
+++ b/Vanilla/source/customskinloader/mixin/MixinThreadDownloadImageDataV2.java
@@ -16,6 +16,11 @@ public abstract class MixinThreadDownloadImageDataV2 {
     @Shadow
     private Runnable processTask;
 
+    @Shadow
+    private static NativeImage processLegacySkin(NativeImage nativeImageIn) {
+        return null;
+    }
+
     @Redirect(
         method = "Lnet/minecraft/client/renderer/ThreadDownloadImageData;loadTexture(Ljava/io/InputStream;)Lnet/minecraft/client/renderer/texture/NativeImage;",
         at = @At(
@@ -24,6 +29,6 @@ public abstract class MixinThreadDownloadImageDataV2 {
         )
     )
     private NativeImage redirect_loadTexture(NativeImage image) {
-        return FakeSkinBuffer.processLegacySkin(image, this.processTask);
+        return FakeSkinBuffer.processLegacySkin(image, this.processTask, MixinThreadDownloadImageDataV2::processLegacySkin);
     }
 }


### PR DESCRIPTION
这个 PR 是为了修复当披风纹理不含鞘翅部分时装备鞘翅不渲染的问题，也就是当披风不包含鞘翅，渲染鞘翅时当作既不存在披风也不存在鞘翅看待；
目前这个实现还有很大的问题，所以暂时设为 Draft。

我大致能想到两种方案：
- 请求皮肤和披风时，如果传回的 `MinecraftProfile.Type` 包含 `CAPE` 但不包含 `ELYTRA`，那么强制设定鞘翅纹理与披风纹理相同，并判断披风是否包含鞘翅，如果不包含，那么强制设定鞘翅纹理为原版问题；
- 请求皮肤和披风时，如果传回的 `MinecraftProfile.Type` 包含 `CAPE` 但不包含 `ELYTRA`，判断披风是否包含鞘翅，如果不包含，将原版鞘翅纹理叠加到披风纹理上。

这个 PR 实现的是第一种方案，但是由于鞘翅渲染时是先判断是否存在鞘翅，再判断是否存在披风，因此这个实现不能兼容包括 OptiFine 和 [Customizable Elytra](https://www.curseforge.com/minecraft/mc-mods/customizable-elytra) 在内的绝大多数能自定义披风和鞘翅的 Mod。
第二种方案的问题在于当玩家切换材质包时，从 CSL 的层面很难及时切换玩家的披风内叠加的鞘翅。