### PR TITLE
Improve skin loading logic.

### DIFF
--- a/Common/source/customskinloader/fake/FakeCapeBuffer.java
+++ b/Common/source/customskinloader/fake/FakeCapeBuffer.java
@@ -97,12 +97,10 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
             if (capeW < elytraW) {
                 this.image = scaleImage(this.image, true, elytraW / (double) capeW, 1, capeW / 64.0D, capeH / 32.0D, elytraW, capeH, 0, 0, 22, 17);
                 capeW = elytraW;
-                this.ratioX = capeW / 64.0D;
             }
             if (capeH < elytraH) {
                 this.image = scaleImage(this.image, true, 1, elytraH / (double) capeH, capeW / 64.0D, capeH / 32.0D, capeW, elytraH, 0, 0, 22, 17);
                 capeH = elytraH;
-                this.ratioY = capeH / 32.0D;
             }
             // elytra part ((22, 0), (45, 21)) -> (24 * 22)
             if (elytraW < capeW) {
@@ -113,6 +111,8 @@ public class FakeCapeBuffer extends FakeSkinBuffer {
                 elytraImage = scaleImage(elytraImage, false, 1, capeH / (double) elytraH, elytraW / 64.0D, elytraH / 32.0D, elytraW, capeH, 22, 0, 46, 22);
                 elytraH = capeH;
             }
+            this.ratioX = capeW / 64.0D;
+            this.ratioY = capeH / 32.0D;
 
             // Overwrite pixels from elytra to cape
             FakeImage finalElytraImage = elytraImage;


### PR DESCRIPTION
- 当关闭 `forceLoadAllTextures` 时，如果某头颅的名称在 A 皮肤站有披风而没有皮肤、在 B 皮肤站有皮肤、且加载顺序为 A -> B 时，按原先的逻辑会在加载到 A 皮肤站的披风时就不再继续获取，现在会在获取到 B 皮肤站的皮肤时才停止；
- 部分服务器会在不同子服务器内让玩家加载不同的皮肤（通过 `GameProfie.properties.textures` 实现），如果前一个子服内的皮肤还在加载，而玩家已经到了下一个子服，那么按照原先的逻辑，玩家会使用之前已经加载的缓存，而不是重新获取当前指定的皮肤；
- 修复了当使用大尺寸鞘翅的资源包切换到小尺寸鞘翅时会崩溃的问题（https://paste.ubuntu.com/p/jvnQHqdMxh/）