### PR TITLE
Fix compatible with OptiFine 1.17.1.

### DIFF
--- a/Forge/Active/resource/transformers.js
+++ b/Forge/Active/resource/transformers.js
@@ -138,8 +138,8 @@ function initializeCoreMod() {
             'transformer': function (mn) {
                 for (var iterator = mn.instructions.iterator(); iterator.hasNext();) {
                     var node = iterator.next();
-                    if (node.getOpcode() === Opcodes.INVOKEVIRTUAL && node.owner.equals("net/minecraft/client/renderer/texture/HttpTexture") && checkName(node.name, "m_118032_") && node.desc.equals("(Lcom/mojang/blaze3d/platform/NativeImage;)Lcom/mojang/blaze3d/platform/NativeImage;")) {
-                        // FakeSkinBuffer.processLegacySkin(image, this.onDownloaded, HttpTexture::processLegacySkin);
+                    if ((node.getOpcode() === Opcodes.INVOKEVIRTUAL || node.getOpcode() === Opcodes.INVOKESPECIAL) && node.owner.equals("net/minecraft/client/renderer/texture/HttpTexture") && checkName(node.name, "m_118032_") && node.desc.equals("(Lcom/mojang/blaze3d/platform/NativeImage;)Lcom/mojang/blaze3d/platform/NativeImage;")) {
+                        // FakeSkinBuffer.processLegacySkin(image, this.onDownloaded, this::processLegacySkin);
                         mn.instructions.insertBefore(node, new InsnNode(Opcodes.SWAP));
                         mn.instructions.insertBefore(node, new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/texture/HttpTexture", mapName("f_117997_"), "Ljava/lang/Runnable;"));
                         mn.instructions.insertBefore(node, new VarInsnNode(Opcodes.ALOAD, 0));


### PR DESCRIPTION
因为 OptiFine 1.17.1 仍然使用 Java 8 编译，所以调用私有方法仍然使用 INVOKESPECIAL 而不是 INVOKEVIRTUAL。