### PR TITLE
Compatible with fabric-loader-0.12.x in development environment.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are the available versions in different environments below:
 |  | Forge | Fabric |
 |:-:|:-:|:-:|
 | Runtime Environment | forge-1.8-11.14.0.1237 ~ 1.13.2-25.0.22<br/> forge-1.13.2-25.0.42 ~ latest | fabric-loader-0.4.3+build.134 ~ latest<br/> Minecraft 18w43b ~ latest<br/> *fabric-api is not required* |
-| Development Environment | ForgeGradle-2.1-SNAPSHOT ~ latest<br/> forge-1.8-11.14.3.1503 ~ 1.12.2-14.23.5.2855<br/> forge-1.13.2-25.0.198 ~ latest | fabric-loom-(?) ~ latest<br/> fabric-loader-0.4.9+build.160 ~ latest<br/> Minecraft 18w49a ~ latest<br/> *fabric-api is not required* |
+| Development Environment | ForgeGradle-2.1-SNAPSHOT ~ latest<br/> forge-1.8-11.14.3.1503 ~ 1.12.2-14.23.5.2855<br/> forge-1.13.2-25.0.198 ~ latest | fabric-loom-(?) ~ latest<br/> fabric-loader-0.12.0 ~ latest<br/> Minecraft 18w49a ~ latest<br/> *fabric-api is not required* |
 
 ### Preliminary steps for testing local builds
 1. Create a new empty minecraft development environment.
@@ -71,7 +71,7 @@ There are the available versions in different environments below:
 1. Add `--tweakClass customskinloader.forge.ForgeDevTweaker --username <Your username>` to CLI arguments in `Run/Debug Configurations` dialog.
 1. Then you can debug the mod in IDE or through `./gradlew runClient` command.
 
-### For ForgeGradle 3.x ~ 4.x ( forge-1.12.2-14.23.5.2851 ~ latest )
+### For ForgeGradle 3.x ~ 5.x ( forge-1.12.2-14.23.5.2851 ~ latest )
 1. Add below contents to `build.gradle`:
    ```gradle
    dependencies {
@@ -89,28 +89,47 @@ There are the available versions in different environments below:
    ```
 1. Setup the development environment and run the game as usual.
 
-### For fabric-loom ( fabric-loader-0.4.9+build.160 ~ latest )
+### For fabric-loom ( fabric-loader-0.12.0 ~ latest )
 1. Add below contents to `build.gradle`:
    ```gradle
    dependencies {
-       modCompile "mods:CustomSkinLoader_Fabric:14.13-SNAPSHOT-00"
+       modImplementation "mods:CustomSkinLoader_Fabric:14.13-SNAPSHOT-00"
+   }
+
+   tasks.runClient {
+	   args += ["--username", "<Your username>"]
    }
    ```
 1. Add `--username <Your username>` to CLI arguments in `Run/Debug Configurations` dialog.
-1. Run the game as usual.
+1. Run the game in IDE or through `./gradlew runClient` command..
 
 ## Depend on release builds
-1. Check the latest version in https://csl.littleservice.cn/latest.json .
+1. Check the latest version in https://littlesk.in/csl-latest .
 1. Add below contents to `build.gradle`:
    ```gradle
+   // Before Gradle 5.x
    repositories {
        ivy {
+           url = "https://csl.littleservice.cn/"
            layout "pattern", {
                artifact "[organisation]/[artifact]-[revision](-[classifier])(.[ext])"
            }
-           url = "https://csl.littleservice.cn/"
        }
    }
+   
+   // After Gradle 6.x
+   repositories {
+       ivy {
+           url = "https://csl.littleservice.cn/"
+           metadataSources {
+               artifact()
+           }
+           patternLayout {
+               artifact "[organisation]/[artifact]-[revision](-[classifier])(.[ext])"
+           }
+       }
+   }
+   ```
 1. Follow the same steps in **Running and Testing**.
 
 ## Developing

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -25,5 +25,5 @@ remapSources project
 
 dependencies {
     // This is the minimum version number that the mod should dependent in the development environment.
-    implementation "net.fabricmc:fabric-loader:0.4.9+build.160"
+    implementation "net.fabricmc:fabric-loader:0.12.0"
 }

--- a/Fabric/source/customskinloader/fabric/DevEnvRemapper.java
+++ b/Fabric/source/customskinloader/fabric/DevEnvRemapper.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 
 import com.google.common.collect.Lists;
 import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.entrypoint.EntrypointTransformer;
-import net.fabricmc.loader.game.MinecraftGameProvider;
+import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.game.patch.GameTransformer;
 import org.apache.commons.io.IOUtils;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -31,9 +31,9 @@ public class DevEnvRemapper extends SimpleRemapper {
         try {
             if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
                 ClassLoader cl = Thread.currentThread().getContextClassLoader();
-                Field patchedClassesField = EntrypointTransformer.class.getDeclaredField("patchedClasses");
+                Field patchedClassesField = GameTransformer.class.getDeclaredField("patchedClasses");
                 patchedClassesField.setAccessible(true);
-                Map<String, byte[]> patchedClasses = (Map<String, byte[]>) patchedClassesField.get(MinecraftGameProvider.TRANSFORMER);
+                Map<String, byte[]> patchedClasses = (Map<String, byte[]>) patchedClassesField.get(FabricLoaderImpl.INSTANCE.getGameProvider().getEntrypointTransformer());
 
                 for (Map.Entry<String, List<String>> entry : remappedClasses.entrySet()) {
                     for (String clazz : entry.getValue()) {


### PR DESCRIPTION
Fabric Loader 0.12 做了一些破坏性修改，因此现在 fabric 开发环境中运行 CSL 至少需要 fabric loader 0.12.0，非开发环境不受影响，仍然可以使用旧版 fabric loader。