### PR TITLE
Fix crash when the URL of skull profiles is not valid.

### DIFF
--- a/Common/src/main/java/customskinloader/fake/FakeMinecraftProfileTexture.java
+++ b/Common/src/main/java/customskinloader/fake/FakeMinecraftProfileTexture.java
@@ -36,7 +36,7 @@ public class FakeMinecraftProfileTexture extends MinecraftProfileTexture {
 
     @Override
     public String getHash() {
-        return Optional.ofNullable(this.info.hash).orElse(super.getHash());
+        return this.info.hash == null ? super.getHash() : this.info.hash;
     }
 
     public File getCacheFile() {

--- a/Common/src/main/java/customskinloader/fake/FakeMinecraftProfileTexture.java
+++ b/Common/src/main/java/customskinloader/fake/FakeMinecraftProfileTexture.java
@@ -2,6 +2,7 @@ package customskinloader.fake;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Optional;
 
 import com.mojang.authlib.minecraft.MinecraftProfileTexture;
 import customskinloader.utils.HttpTextureUtil;
@@ -35,7 +36,7 @@ public class FakeMinecraftProfileTexture extends MinecraftProfileTexture {
 
     @Override
     public String getHash() {
-        return this.info.hash;
+        return Optional.ofNullable(this.info.hash).orElse(super.getHash());
     }
 
     public File getCacheFile() {


### PR DESCRIPTION
Fix #254 