### PR TITLE
wiki.vg 已关闭，将与 Mojang API Wiki 相关的地址更改至 Minecraft Wiki

### DIFF
--- a/Common/src/main/java/customskinloader/loader/MojangAPILoader.java
+++ b/Common/src/main/java/customskinloader/loader/MojangAPILoader.java
@@ -118,7 +118,7 @@ public class MojangAPILoader implements ICustomSkinLoaderPlugin, ProfileLoader.I
 
     //Username -> UUID
     public static GameProfile loadGameProfile(String apiRoot, String username) {
-        //Doc (https://wiki.vg/Mojang_API#Playernames_-.3E_UUIDs)
+        //Doc (https://minecraft.wiki/w/Mojang_API#Query_player_UUIDs_in_batch)
         HttpRequestUtil.HttpResponce responce = HttpRequestUtil.makeHttpRequest(new HttpRequestUtil.HttpRequest(apiRoot + "profiles/minecraft").setCacheTime(600).setPayload(GSON.toJson(Collections.singletonList(username))));
         if (StringUtils.isEmpty(responce.content)) {
             return null;
@@ -154,7 +154,7 @@ public class MojangAPILoader implements ICustomSkinLoaderPlugin, ProfileLoader.I
 
     //UUID -> Profile
     public static GameProfile fillGameProfile(String sessionRoot, GameProfile profile) {
-        //Doc (http://wiki.vg/Mojang_API#UUID_-.3E_Profile_.2B_Skin.2FCape)
+        //Doc (https://minecraft.wiki/w/Mojang_API#Query_player's_skin_and_cape)
         HttpRequestUtil.HttpResponce responce = HttpRequestUtil.makeHttpRequest(new HttpRequestUtil.HttpRequest(sessionRoot + "session/minecraft/profile/" + TextureUtil.fromUUID(profile.getId())).setCacheTime(90));
         if (StringUtils.isEmpty(responce.content)) {
             return profile;

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The problem of incorrectly rendering textures has been fixed.
 By using this mod, you can see correct avatar of players in Spectator Menu rather than steve and alex.  
   
 ## Default Load List  
-- [Mojang](http://www.minecraft.net/) (MojangAPI)
+- [Mojang](https://minecraft.wiki/w/Mojang_API) (MojangAPI)
 - [LittleSkin](https://littleskin.cn/) (CustomSkinAPI)  
 - [BlessingSkin](http://skin.prinzeugen.net/) (CustomSkinAPI)
 - [ElyBy](http://docs.ely.by/) (ElyByAPI)


### PR DESCRIPTION
[wiki.vg](https://wiki.vg/) 已于2024年11月30日关站，现已无法访问，中英文 Minecraft Wiki 已完成迁移 Mojang API 相关内容，故更新链接到 Minecraft Wiki
[中文 Minecraft Wiki 相关问题讨论版](https://zh.minecraft.wiki/w/Minecraft_Wiki:%E8%AE%BA%E5%9D%9B/%E5%85%B3%E4%BA%8Ewiki.vg%E5%86%85%E5%AE%B9%E7%9A%84%E6%8E%A5%E6%94%B6%E9%97%AE%E9%A2%98?variant=zh-cn)
[Minecraft Wiki:Projects/wiki.vg merge（English）](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge)
[官方公告](https://tkte.ch/articles/2024/11/11/sunsetting.html)